### PR TITLE
Add base64 to jbuilder.gemspec and gemfiles

### DIFF
--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -6,5 +6,6 @@ gem "rake"
 gem "mocha", require: false
 gem "appraisal"
 gem "rails", "~> 6.0.0"
+gem "base64"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -6,5 +6,6 @@ gem "rake"
 gem "mocha", require: false
 gem "appraisal"
 gem "rails", "~> 6.1.0"
+gem "base64"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -6,5 +6,6 @@ gem "rake"
 gem "mocha", require: false
 gem "appraisal"
 gem "rails", "~> 7.0.0"
+gem "base64"
 
 gemspec path: "../"

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 5.0.0'
   s.add_dependency 'actionview', '>= 5.0.0'
+  s.add_dependency 'base64'
 
   if RUBY_ENGINE == 'rbx'
     s.add_development_dependency('racc')


### PR DESCRIPTION
This commit adds base64 gem to rails_6_0.gemfiles, rails_6_1.gemfiles and rails_7_0.gemfiles in gemfiles directory and jbuilder.gemspec for the following reasons.

- Starting from Ruby 3.3, using base64 raises the following warning.

> warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of activesupport-6.0.6.1 to add base64 into its gemspec.

- The reason for not adding gems to rails7_1.gemfiles and rails_head.gemfiles is that the base64 gem has been added to activesupport.gemspec since ActiveSupport 7.1 with add_dependency.

- The reason for adding the gem to jbuiilder.gemfiles is that the developer may be using Ruby 3.3 and less than Rails 7.1.

Refer to
https://bugs.ruby-lang.org/issues/20187
https://github.com/ruby/ruby/pull/9550
https://github.com/rails/rails/blob/v7.1.0/activesupport/activesupport.gemspec